### PR TITLE
Create an action that helps require consistent naming

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,28 @@
+name: Validation tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+    working-directory: knowledge-graph
+
+jobs:
+  validation-tests:
+    runs-on: ubuntu-latest
+    name: Validation tests
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        path: knowledge-graph
+
+    - name: Verify content
+      run: |
+        ./build/validate.sh

--- a/build/validate.sh
+++ b/build/validate.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+rc=0
+files=$(ls input)
+for file in $files; do
+	label=$(xmllint --nocdata --xpath "//*[local-name()='graphml']/*[local-name()='key'][@for='node'][@attr.name='label']/@id" input/$file | awk -F\" '{print $2}')
+	#echo "Label=$label"
+	nodes=$(xmllint --nocdata --xpath "//*[local-name()='graph']/*[local-name()='node']/*[local-name()='data'][@key=\"$label\"]/text()" "input/$file" | sort | uniq)
+
+	for node in $nodes; do
+		grep -q "^$node\$" glossary.txt
+		if [ $? -ne 0 ]; then
+			rc=1
+			echo "Error: Node not in glossary: $node"
+		fi
+	done
+done
+
+exit $rc

--- a/glossary.txt
+++ b/glossary.txt
@@ -1,0 +1,17 @@
+# Add only unique entries that don't duplicate the meaning of an existing entry
+Category
+CertificatePolicy
+ConfigurationPolicy
+CreditCard
+Deployment
+Event
+IAMPolicy
+Person
+Placement
+PlacementBinding
+Policy
+PolicyAutomation
+Pos
+SocialMedia
+Store
+Transaction


### PR DESCRIPTION
Naming in knowledge graphs is something that is going to be difficult to validate.  This sets up some initial validate to help detect when names aren't being used from the glossary file.  I expect some checks should be run against the glossary too (TBD)