### PR TITLE
Adjust naming to try to standardize a simple format

### DIFF
--- a/doc/naming.md
+++ b/doc/naming.md
@@ -1,0 +1,54 @@
+# Naming
+
+## Overview
+
+To have consistent naming not only do we need some controls but we need agreement on what naming in the knowledge graph means.  
+This guide provides some details on our naming strategy.
+
+## Components
+
+A knowledge graph consists of nodes and edges.  The nodes have names and multiple key attributes.  The edges are a verb that
+relates one node to another node.  For example, Node A "creates" Node B.  The edge between Node A and Node B is the "creates"
+verb.  
+
+## Nodes
+
+The nodes are entities in the knowledge graph system.  An entity key is required to be specified for each node that you define
+in the knowledge graph and it is expected these entity names will be re-used many times.  Examples of entities are given below,
+and each entity must also define a name key that further clarifies the unique characteristic of that entity so you know which 
+entity type is being referred to.
+
+- Users: A resource representing users within the knowledge domain.
+  - name: Which sets of users is being identified. Could be User for a generic user or Admin, SecOps, etc
+- API: A resource in the system that implements an API.  This could be a deployment/pod/controller resource or it could be the
+  API definition (CRD).
+  - name: Which API is being referred to.  This could be Policy since Policy is an API in the ACM kubernetes installations.
+  - 
+- Processor: An entity focused on performing tasks of some form.  Such as a pod/container/deployment.
+  - name: The well known name for the entity agreed upon in the glossary of names.
+  - 
+- Custom Resource: An entity that is an instance of an API that may be directly created and used in various ways.
+  - name: the custom resource name
+- Intermediate Resource: An entity that is an instance of an API that is indirectly created and the use is not the focus of
+  the creating entity.
+  - name: this is also the custom resource name but it's an intermediate resource and needs a better explanation.  
+  -
+
+
+## Edges
+
+The relation between nodes is the edge.  Ideally I think we want to keep edges structured so common verbs/relations are 
+re-used as much as possible.  Examples of edges are:
+
+- Creates
+- Reads
+- Updates
+- Deletes
+- Patches
+- Forwards
+- Refers
+- Watches
+- Configures
+- Tests
+
+Etc

--- a/input/kg-test-acm-grc.graphml
+++ b/input/kg-test-acm-grc.graphml
@@ -4,112 +4,107 @@
   <key id="userCreated" for="node" attr.name="userCreated" attr.type="boolean" />
   <key id="onHub" for="node" attr.name="onHub" attr.type="boolean" />
   <key id="onManaged" for="node" attr.name="onManaged" attr.type="boolean" />
-  <key id="replicas" for="node" attr.name="replicas" attr.type="int" />
   <key id="name" for="node" attr.name="name" attr.type="string" />
-  <key id="label" for="node" attr.name="label" attr.type="string" />
+  <key id="entity" for="node" attr.name="entity" attr.type="string" />
   <key id="type" for="node" attr.name="type" attr.type="string" />
   <key id="namespace" for="node" attr.name="namespace" attr.type="string" />
   <graph edgedefault="directed">
     <node id="1">
-      <data key="label">Deployment</data>
+      <data key="entity">Processor</data>
       <data key="name">grc-policy-propagator</data>
       <data key="userCreated">false</data>
       <data key="onHub">true</data>
       <data key="onManaged">false</data>
       <data key="namespace">open-cluster-management</data>
-      <data key="replicas">2</data>
     </node>
     <node id="2">
-      <data key="label">Policy</data>
-      <data key="name">policy-sample</data>
+      <data key="entity">Custom Resource</data>
+      <data key="name">Policy</data>
       <data key="userCreated">true</data>
       <data key="onHub">true</data>
       <data key="onManaged">false</data>
     </node>
     <node id="3">
-      <data key="label">Deployment</data>
+      <data key="entity">Processor</data>
       <data key="name">policy-framework</data>
       <data key="namespace">open-cluster-management-agent-addon</data>
-      <data key="replicas">1</data>
       <data key="onHub">true</data>
       <data key="onManaged">true</data>
     </node>
     <node id="4">
-      <data key="label">Event</data>
+      <data key="entity">API</data>
+      <data key="name">Event</data>
       <data key="namespace">ManagedCluster Namespace</data>
       <data key="onHub">true</data>
       <data key="onManaged">true</data>
     </node>
     <node id="6">
-      <data key="label">Deployment</data>
+      <data key="entity">Processor</data>
       <data key="name">config-policy-controller</data>
       <data key="namespace">open-cluster-management-agent-addon</data>
-      <data key="replicas">1</data>
       <data key="onHub">true</data>
       <data key="onManaged">true</data>
     </node>
     <node id="7">
-      <data key="label">Policy</data>
-      <data key="name">policy-sample</data>
+      <data key="entity">Intermediate Resource</data>
+      <data key="name">Policy</data>
       <data key="userCreated">false</data>
       <data key="onHub">true</data>
       <data key="onManaged">true</data>
     </node>
     <node id="8">
-      <data key="label">PolicyAutomation</data>
-      <data key="name">policy-sample-policy-automation</data>
+      <data key="entity">Custom Resource</data>
+      <data key="name">PolicyAutomation</data>
       <data key="userCreated">true</data>
       <data key="type">Ansible</data>
       <data key="onHub">true</data>
       <data key="onManaged">false</data>
     </node>
     <node id="9">
-      <data key="label">PlacementBinding</data>
-      <data key="name">binding-policy-sample</data>
+      <data key="entity">Custom Resource</data>
+      <data key="name">PlacementBinding</data>
       <data key="userCreated">true</data>
       <data key="onHub">true</data>
       <data key="onManaged">false</data>
     </node>
     <node id="10">
-      <data key="label">Placement</data>
-      <data key="name">placement-policy-sample</data>
+      <data key="entity">Custom Resource</data>
+      <data key="name">Placement</data>
       <data key="userCreated">true</data>
       <data key="onHub">true</data>
       <data key="onManaged">false</data>
     </node>
     <node id="18">
-      <data key="label">CertificatePolicy</data>
-      <data key="name">policy-cert-sample</data>
+      <data key="entity">Custom Resource</data>
+      <data key="name">CertificatePolicy</data>
       <data key="type">Policy Template</data>
       <data key="onHub">true</data>
       <data key="onManaged">true</data>
     </node>
     <node id="19">
-      <data key="label">ConfigurationPolicy</data>
-      <data key="name">policy-config-sample</data>
+      <data key="entity">Custom Resource</data>
+      <data key="name">ConfigurationPolicy</data>
       <data key="type">Policy Template</data>
       <data key="onHub">true</data>
       <data key="onManaged">true</data>
     </node>
     <node id="20">
-      <data key="label">Deployment</data>
+      <data key="entity">Processor</data>
       <data key="name">cert-policy-controller</data>
       <data key="namespace">open-cluster-management-agent-addon</data>
-      <data key="replicas">1</data>
       <data key="onHub">true</data>
       <data key="onManaged">true</data>
     </node>
     <node id="21">
-      <data key="label">Deployment</data>
+      <data key="entity">Processor</data>
       <data key="name">iam-policy-controller</data>
       <data key="namespace">open-cluster-management-agent-addon</data>
-      <data key="replicas">1</data>
       <data key="onHub">true</data>
       <data key="onManaged">true</data>
     </node>
     <node id="22">
-      <data key="label">IAMPolicy</data>
-      <data key="name">policy-iam-sample</data>
+      <data key="entity">Custom Resource</data>
+      <data key="name">IAMPolicy</data>
       <data key="type">Policy Template</data>
       <data key="onHub">true</data>
       <data key="onManaged">true</data>


### PR DESCRIPTION
Let's use naming that is simple and easy for others to pick up quickly.  Does this naming work well?  Summary:
- label changed to entity
- removed replicas
- Switched from the label being a kubernetes resource to a basic value like API, Custom Resource, etc
- the name now matches an actual name of the resource.