### PR TITLE
Redo the grc test sample to match new ontology

### DIFF
--- a/input/kg-acm-grc-repo-tests.graphml
+++ b/input/kg-acm-grc-repo-tests.graphml
@@ -4,883 +4,221 @@
   <key id="name" for="node" attr.name="name" attr.type="string" />
   <key id="entity" for="node" attr.name="entity" attr.type="string" />
   <key id="type" for="node" attr.name="type" attr.type="string" />
-  <key id="branch" for="node" attr.name="branch" attr.type="string" />
+  <key id="group" for="node" attr.name="group" attr.type="string" />
+  <key id="kind" for="node" attr.name="kind" attr.type="string" />
   <graph edgedefault="directed">
     <node id="1">
       <data key="entity">Repository</data>
-      <data key="name">open-cluster-management-io/config-policy-controller</data>
+      <data key="name">Open Cluster Management</data>
       <data key="type">github</data>
-      <data key="branch">main</data>
+      <data key="group">policy</data>
+      <data key="kind">main</data>
     </node>
     <node id="2">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (minimum)</data>
-      <data key="type">prow</data>
+      <data key="entity">API</data>
+      <data key="name">KinD Tests</data>
+      <data key="type">Pipeline</data>
+      <data key="group">policy</data>
+      <data key="kind">integration</data>
     </node>
-    <edge source="2" target="1">
-      <data key="verb">Test</data>
-    </edge>
     <node id="3">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (latest)</data>
-      <data key="type">prow</data>
+      <data key="entity">Users</data>
+      <data key="name">User</data>
     </node>
-    <edge source="3" target="1">
-      <data key="verb">Test</data>
-    </edge>
     <node id="4">
-      <data key="entity">Repository</data>
-      <data key="name">open-cluster-management-io/governance-policy-addon-controller</data>
+      <data key="entity">API</data>
+      <data key="name">Pull Request</data>
       <data key="type">github</data>
-      <data key="branch">main</data>
     </node>
     <node id="5">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (minimum true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="5" target="4">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="6">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (latest true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="6" target="4">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="7">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (minimum false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="7" target="4">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="8">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (latest false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="8" target="4">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="9">
-      <data key="entity">Test</data>
-      <data key="name">Linting and Unit Tests</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="9" target="4">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="10">
-      <data key="entity">Repository</data>
-      <data key="name">open-cluster-management-io/governance-policy-framework-addon</data>
+      <data key="entity">Processor</data>
+      <data key="name">Github Actions</data>
       <data key="type">github</data>
-      <data key="branch">main</data>
+    </node>
+    <node id="6">
+      <data key="entity">API</data>
+      <data key="name">Lint and Format Tests</data>
+      <data key="type">Pipeline</data>
+      <data key="group">policy</data>
+      <data key="kind">Unit</data>
+    </node>
+    <node id="7">
+      <data key="entity">API</data>
+      <data key="name">Go Unit Tests</data>
+      <data key="type">Pipeline</data>
+      <data key="group">policy</data>
+      <data key="kind">Unit</data>
+    </node>
+    <node id="8">
+      <data key="entity">Processor</data>
+      <data key="name">GRC E2E</data>
+      <data key="type">Periodic E2E Testing</data>
+      <data key="group">policy</data>
+      <data key="kind">Integration</data>
     </node>
     <node id="11">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (minimum)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="11" target="10">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="12">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (latest)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="12" target="10">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="13">
       <data key="entity">Repository</data>
-      <data key="name">open-cluster-management-io/governance-policy-propagator</data>
+      <data key="name">stolostron</data>
       <data key="type">github</data>
-      <data key="branch">main</data>
+      <data key="group">policy</data>
+      <data key="kind">main</data>
+    </node>
+    <node id="12">
+      <data key="entity">API</data>
+      <data key="name">Framework KinD Tests (version local/remote/hosted)</data>
+      <data key="type">Pipeline</data>
+      <data key="group">policy</data>
+      <data key="kind">integration</data>
+    </node>
+    <node id="13">
+      <data key="entity">API</data>
+      <data key="name">Upstream reference checks</data>
+      <data key="type">Pipeline</data>
+      <data key="group">GRC</data>
+      <data key="kind">Unit</data>
     </node>
     <node id="14">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (minimum)</data>
-      <data key="type">prow</data>
+      <data key="entity">API</data>
+      <data key="name">Code scanning results</data>
+      <data key="type">Pipeline</data>
+      <data key="group">policy</data>
+      <data key="kind">Integration</data>
     </node>
-    <edge source="14" target="13">
-      <data key="verb">Test</data>
-    </edge>
     <node id="15">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (latest)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="15" target="13">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="16">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests PolicyAutomation</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="16" target="13">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="17">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests Unit Tests</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="17" target="13">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="18">
-      <data key="entity">Repository</data>
-      <data key="name">open-cluster-management-io/policy-collection</data>
-      <data key="type">github</data>
-      <data key="branch">main</data>
+      <data key="entity">API</data>
+      <data key="name">SonarCloud Code Analysis</data>
+      <data key="type">Pipeline</data>
+      <data key="group">policy</data>
+      <data key="kind">Integration</data>
     </node>
     <node id="19">
-      <data key="entity">Test</data>
-      <data key="name">Validation Tests</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="19" target="18">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="20">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/cert-policy-controller</data>
-      <data key="type">github</data>
-      <data key="branch">main</data>
+      <data key="entity">API</data>
+      <data key="name">Policy Framework e2e Suite</data>
+      <data key="type">Pipeline</data>
+      <data key="group">policy</data>
+      <data key="kind">E2E</data>
     </node>
     <node id="21">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (minimum)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="21" target="20">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="22">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (latest)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="22" target="20">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="23">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (minimum true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="23" target="20">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="24">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (latest true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="24" target="20">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="25">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (minimum false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="25" target="20">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="26">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (latest false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="26" target="20">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="27">
-      <data key="entity">Test</data>
-      <data key="name">Upstream reference checks</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="27" target="20">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="28">
-      <data key="entity">Test</data>
-      <data key="name">Code scanning results</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="28" target="20">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="29">
-      <data key="entity">Test</data>
-      <data key="name">SonarCloud Code Analysis</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="29" target="20">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="30">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/config-policy-controller</data>
-      <data key="type">github</data>
-      <data key="branch">main</data>
-    </node>
-    <node id="31">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (minimum)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="31" target="30">
-      <data key="verb">Test</data>
-    </edge>
-    <edge source="1" target="30">
-      <data key="verb">MirrorTo</data>
-    </edge>
-    <node id="32">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (latest)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="32" target="30">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="33">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (minimum true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="33" target="30">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="34">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (latest true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="34" target="30">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="35">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (minimum false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="35" target="30">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="36">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (latest false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="36" target="30">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="37">
-      <data key="entity">Test</data>
-      <data key="name">Upstream reference checks</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="37" target="30">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="38">
-      <data key="entity">Test</data>
-      <data key="name">Code scanning results</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="38" target="30">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="39">
-      <data key="entity">Test</data>
-      <data key="name">SonarCloud Code Analysis</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="39" target="30">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="40">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/go-template-utils</data>
-      <data key="type">github</data>
-      <data key="branch">main</data>
-    </node>
-    <node id="41">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/governance-policy-addon-controller</data>
-      <data key="type">github</data>
-      <data key="branch">main</data>
-    </node>
-    <node id="42">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (minimum true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="42" target="41">
-      <data key="verb">Test</data>
-    </edge>
-    <edge source="4" target="42">
-      <data key="verb">MirrorTo</data>
-    </edge>
-    <node id="43">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (latest true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="43" target="41">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="44">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (minimum false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="44" target="41">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="45">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (latest false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="45" target="41">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="46">
-      <data key="entity">Test</data>
-      <data key="name">Linting and Unit Tests</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="46" target="41">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="47">
-      <data key="entity">Test</data>
-      <data key="name">Upstream reference checks</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="47" target="41">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="48">
-      <data key="entity">Test</data>
-      <data key="name">Code scanning results</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="48" target="41">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="49">
-      <data key="entity">Test</data>
-      <data key="name">SonarCloud Code Analysis</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="49" target="41">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="50">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/governance-policy-framework</data>
-      <data key="type">github</data>
-      <data key="branch">main</data>
-    </node>
-    <node id="51">
-      <data key="entity">Test</data>
-      <data key="name">E2E Framework KinD Tests (minumum true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="51" target="50">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="52">
-      <data key="entity">Test</data>
-      <data key="name">E2E Framework KinD Tests (minumum false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="52" target="50">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="53">
-      <data key="entity">Test</data>
-      <data key="name">E2E Framework KinD Tests (latest false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="53" target="50">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="54">
-      <data key="entity">Test</data>
-      <data key="name">E2E Framework KinD Tests (latest true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="54" target="50">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="55">
-      <data key="entity">Test</data>
-      <data key="name">E2E Framework KinD Tests (latest false hosted)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="55" target="50">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="56">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/governance-policy-framework-addon</data>
-      <data key="type">github</data>
-      <data key="branch">main</data>
-    </node>
-    <node id="57">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (minimum)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="57" target="56">
-      <data key="verb">Test</data>
-    </edge>
-    <edge source="10" target="56">
-      <data key="verb">MirrorTo</data>
-    </edge>
-    <node id="58">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (latest)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="58" target="56">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="59">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (minimum true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="59" target="56">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="60">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (latest true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="60" target="56">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="61">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (minimum false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="61" target="56">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="62">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (latest false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="62" target="56">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="63">
-      <data key="entity">Test</data>
-      <data key="name">Upstream reference checks</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="63" target="56">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="64">
-      <data key="entity">Test</data>
-      <data key="name">Code scanning results</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="64" target="56">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="65">
-      <data key="entity">Test</data>
-      <data key="name">SonarCloud Code Analysis</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="65" target="56">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="66">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/governance-policy-propagator</data>
-      <data key="type">github</data>
-      <data key="branch">main</data>
-    </node>
-    <node id="67">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (minimum)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="67" target="66">
-      <data key="verb">Test</data>
-    </edge>
-    <edge source="13" target="66">
-      <data key="verb">MirrorTo</data>
-    </edge>
-    <node id="68">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (latest)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="68" target="66">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="69">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (minimum true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="69" target="66">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="70">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (latest true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="70" target="66">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="71">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (minimum false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="71" target="66">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="72">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (latest false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="72" target="66">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="73">
-      <data key="entity">Test</data>
-      <data key="name">Upstream reference checks</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="73" target="66">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="74">
-      <data key="entity">Test</data>
-      <data key="name">Code scanning results</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="74" target="66">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="75">
-      <data key="entity">Test</data>
-      <data key="name">SonarCloud Code Analysis</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="75" target="66">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="76">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/go-template-utils</data>
-      <data key="type">github</data>
-      <data key="branch">main</data>
-    </node>
-    <node id="77">
-      <data key="entity">Test</data>
-      <data key="name">Linting</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="77" target="76">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="78">
-      <data key="entity">Test</data>
-      <data key="name">Unit Tests</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="78" target="76">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="79">
-      <data key="entity">Test</data>
-      <data key="name">Code scanning results</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="79" target="76">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="80">
-      <data key="entity">Test</data>
-      <data key="name">SonarCloud Code Analysis</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="80" target="76">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="81">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/iam-policy-controller</data>
-      <data key="type">github</data>
-      <data key="branch">main</data>
-    </node>
-    <node id="82">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (minimum)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="82" target="81">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="83">
-      <data key="entity">Test</data>
-      <data key="name">KinD Tests (latest)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="83" target="81">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="84">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (minimum true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="84" target="81">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="85">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (latest true)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="85" target="81">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="86">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (minimum false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="86" target="81">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="87">
-      <data key="entity">Test</data>
-      <data key="name">Framework KinD Tests (latest false)</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="87" target="81">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="88">
-      <data key="entity">Test</data>
-      <data key="name">Upstream reference checks</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="88" target="81">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="89">
-      <data key="entity">Test</data>
-      <data key="name">Code scanning results</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="89" target="81">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="90">
-      <data key="entity">Test</data>
-      <data key="name">SonarCloud Code Analysis</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="90" target="81">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="91">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/policy-collection</data>
-      <data key="type">github</data>
-      <data key="branch">main</data>
-    </node>
-    <node id="92">
-      <data key="entity">Test</data>
-      <data key="name">Validation Tests</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="92" target="91">
-      <data key="verb">Test</data>
-    </edge>
-    <edge source="18" target="91">
-      <data key="verb">MirrorTo</data>
-    </edge>
-    <node id="93">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/governance-policy-framework</data>
-      <data key="type">github</data>
-    </node>
-    <node id="94">
-      <data key="entity">Test</data>
-      <data key="name">Policy Framework e2e Suite</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="94" target="93">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="95">
-      <data key="entity">Test</data>
-      <data key="name">Policy Framework e2e Suite deployOnHub</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="95" target="93">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="96">
-      <data key="entity">Test</data>
-      <data key="name">GRC framework integration test suite</data>
-      <data key="type">prow</data>
-    </node>
-    <edge source="96" target="93">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="97">
       <data key="entity">Repository</data>
       <data key="name">stolostron/canary</data>
       <data key="type">github</data>
+      <data key="group">CICD</data>
+      <data key="kind">canary</data>
     </node>
-    <node id="98">
-      <data key="entity">Test</data>
-      <data key="name">BVT GRC framework integration test suite</data>
-      <data key="type">prow</data>
+    <node id="22">
+      <data key="entity">API</data>
+      <data key="name">CICD BVT GRC framework integration test suite</data>
+      <data key="type">Pipeline</data>
+      <data key="group">policy</data>
+      <data key="kind">E2E</data>
     </node>
-    <edge source="98" target="97">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="99">
-      <data key="entity">Test</data>
-      <data key="name">SVT GRC framework integration test suite</data>
-      <data key="type">prow</data>
+    <node id="23">
+      <data key="entity">API</data>
+      <data key="name">CICD SVT GRC framework integration test suite</data>
+      <data key="type">Pipeline</data>
+      <data key="group">policy</data>
+      <data key="kind">E2E</data>
     </node>
-    <edge source="99" target="97">
-      <data key="verb">Test</data>
-    </edge>
-    <node id="100">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/cert-policy-controller</data>
-      <data key="type">github</data>
-      <data key="branch">release-x.y</data>
+    <node id="24">
+      <data key="entity">Processor</data>
+      <data key="name">Canary</data>
+      <data key="type">Pipeline</data>
+      <data key="group">CICD</data>
+      <data key="kind">release</data>
     </node>
-    <node id="101">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/config-policy-controller</data>
-      <data key="type">github</data>
-      <data key="branch">release-x.y</data>
-    </node>
-    <node id="102">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/iam-policy-controller</data>
-      <data key="type">github</data>
-      <data key="branch">release-x.y</data>
-    </node>
-    <node id="103">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/governance-policy-propagator</data>
-      <data key="type">github</data>
-      <data key="branch">release-x.y</data>
-    </node>
-    <node id="104">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/governance-policy-framework-addon</data>
-      <data key="type">github</data>
-      <data key="branch">release-x.y</data>
-    </node>
-    <node id="105">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/governance-policy-addon-controller</data>
-      <data key="type">github</data>
-      <data key="branch">release-x.y</data>
-    </node>
-    <node id="106">
-      <data key="entity">Repository</data>
-      <data key="name">stolostron/pipeline</data>
-      <data key="type">github</data>
-      <data key="branch">release-x.y</data>
-    </node>
-    <node id="107">
-      <data key="entity">Process</data>
+    <node id="25">
+      <data key="entity">Processor</data>
       <data key="name">FastForwardGate</data>
-      <data key="type">script</data>
-      <data key="branch">release-x.y</data>
+      <data key="type">Pipeline</data>
+      <data key="group">policy</data>
+      <data key="kind">release</data>
     </node>
-    <edge source="107" target="20">
-      <data key="verb">RequestFastForward</data>
+
+    <edge source="2" target="4">
+      <data key="verb">Tests</data>
     </edge>
-    <edge source="107" target="30">
-      <data key="verb">RequestFastForward</data>
+    <edge source="3" target="4">
+      <data key="verb">Creates</data>
     </edge>
-    <edge source="107" target="41">
-      <data key="verb">RequestFastForward</data>
+    <edge source="5" target="4">
+      <data key="verb">Watches</data>
     </edge>
-    <edge source="107" target="56">
-      <data key="verb">RequestFastForward</data>
+    <edge source="5" target="2">
+      <data key="verb">Creates</data>
     </edge>
-    <edge source="107" target="66">
-      <data key="verb">RequestFastForward</data>
+    <edge source="5" target="7">
+      <data key="verb">Creates</data>
     </edge>
-    <edge source="107" target="81">
-      <data key="verb">RequestFastForward</data>
+
+    <edge source="5" target="6">
+      <data key="verb">Creates</data>
     </edge>
-    <edge source="20" target="100">
+    <edge source="5" target="12">
+      <data key="verb">Creates</data>
+    </edge>
+    <edge source="5" target="13">
+      <data key="verb">Creates</data>
+    </edge>
+    <edge source="5" target="14">
+      <data key="verb">Creates</data>
+    </edge>
+    <edge source="5" target="15">
+      <data key="verb">Creates</data>
+    </edge>
+    <edge source="24" target="22">
+      <data key="verb">Creates</data>
+    </edge>
+    <edge source="24" target="23">
+      <data key="verb">Creates</data>
+    </edge>
+    <edge source="24" target="21">
+      <data key="verb">Uses</data>
+    </edge>
+
+    
+    <edge source="6" target="4">
+      <data key="verb">Tests</data>
+    </edge>
+    <edge source="7" target="4">
+      <data key="verb">Tests</data>
+    </edge>
+    <edge source="12" target="4">
+      <data key="verb">Tests</data>
+    </edge>
+    <edge source="13" target="4">
+      <data key="verb">Tests</data>
+    </edge>
+    <edge source="14" target="4">
+      <data key="verb">Tests</data>
+    </edge>
+    <edge source="15" target="4">
+      <data key="verb">Tests</data>
+    </edge>
+    <edge source="19" target="11">
+      <data key="verb">Tests</data>
+    </edge>
+
+    <edge source="22" target="11">
+      <data key="verb">Tests</data>
+    </edge>
+    <edge source="23" target="11">
+      <data key="verb">Tests</data>
+    </edge>
+    
+    <edge source="8" target="19">
+      <data key="verb">Starts</data>
+    </edge>
+    <edge source="3" target="1">
+      <data key="verb">Forks</data>
+    </edge>
+    <edge source="25" target="19">
+      <data key="verb">Watches</data>
+    </edge>
+    <edge source="25" target="11">
       <data key="verb">FastForward</data>
     </edge>
-    <edge source="30" target="101">
-      <data key="verb">FastForward</data>
-    </edge>
-    <edge source="41" target="105">
-      <data key="verb">FastForward</data>
-    </edge>
-    <edge source="56" target="104">
-      <data key="verb">FastForward</data>
-    </edge>
-    <edge source="66" target="103">
-      <data key="verb">FastForward</data>
-    </edge>
-    <edge source="81" target="102">
-      <data key="verb">FastForward</data>
-    </edge>
-    <edge source="100" target="106">
-      <data key="verb">Publish</data>
-    </edge>
-    <edge source="101" target="106">
-      <data key="verb">Publish</data>
-    </edge>
-    <edge source="102" target="106">
-      <data key="verb">Publish</data>
-    </edge>
-    <edge source="103" target="106">
-      <data key="verb">Publish</data>
-    </edge>
-    <edge source="104" target="106">
-      <data key="verb">Publish</data>
-    </edge>
-    <edge source="105" target="106">
-      <data key="verb">Publish</data>
-    </edge>
-    <edge source="106" target="97">
-      <data key="verb">GetPublished</data>
+    <edge source="3" target="11">
+      <data key="verb">Forks</data>
     </edge>
   </graph>
 </graphml>


### PR DESCRIPTION
This is a big simplification to the GRC tests sample.  It may be over simplified now, but it uses the ontology we discussed and provides the basic knowledge for how the testing in GRC works.